### PR TITLE
logback.xml absolute path

### DIFF
--- a/src/de/infsec/tpl/TplCLI.java
+++ b/src/de/infsec/tpl/TplCLI.java
@@ -470,7 +470,7 @@ public class TplCLI {
 			JoranConfigurator configurator = new JoranConfigurator();
 		    configurator.setContext(context);
 		    context.reset();  // clear any previous configuration 
-		    configurator.doConfigure("./logging/logback.xml");   
+		    configurator.doConfigure("/root/LibScout/logging/logback.xml");   
 		    
 	    	ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 	    	switch (CliOptions.logType) {


### PR DESCRIPTION
in order to offer more flexibilty and make it possible to run LibScout from any directory so we can avoid getting this error message Could not open [./logging/logback.xml]. i simply put the absolute path of the logback.xml file instead of the its relative path in line 473.